### PR TITLE
Fix relation rollback on failed transaction

### DIFF
--- a/iron-core/src/main/java/io/axway/iron/core/internal/entity/EntityStore.java
+++ b/iron-core/src/main/java/io/axway/iron/core/internal/entity/EntityStore.java
@@ -126,8 +126,8 @@ public class EntityStore<E> {
             if (relationStore instanceof RelationSimpleStore) {
                 RelationSimpleStore relationSimpleStore = (RelationSimpleStore) relationStore;
                 if (value != null) {
-                    InstanceProxy headInstanceProxy = InstanceProxy.class.cast(value);
-                    oldValue = relationSimpleStore.set(instance.__id(), headInstanceProxy.__id());
+                    long headInstanceId = value instanceof Long ? (long) value : InstanceProxy.class.cast(value).__id();
+                    oldValue = relationSimpleStore.set(instance.__id(), headInstanceId);
                 } else {
                     oldValue = relationSimpleStore.remove(instance.__id());
                 }
@@ -135,7 +135,8 @@ public class EntityStore<E> {
                 RelationMultipleStore relationMultipleStore = (RelationMultipleStore) relationStore;
                 if (value != null) {
                     Collection<?> collection = (Collection<?>) value;
-                    Collection<Long> idCollection = collection.stream().map(o -> InstanceProxy.class.cast(o).__id()).collect(Collectors.toList());
+                    Collection<Long> idCollection = collection.stream().map(o -> o instanceof Long ? (Long) o : InstanceProxy.class.cast(o).__id())
+                            .collect(Collectors.toList());
                     oldValue = relationMultipleStore.set(instance.__id(), idCollection);
                 } else {
                     oldValue = relationMultipleStore.clear(instance.__id());

--- a/iron-core/src/test/java/io/axway/iron/core/store/AbstractStoreTests.java
+++ b/iron-core/src/test/java/io/axway/iron/core/store/AbstractStoreTests.java
@@ -52,7 +52,7 @@ public abstract class AbstractStoreTests {
         return result;
     }
 
-    @Test(dataProvider = "succeedingStoreTests")
+    @Test(dataProvider = "succeedingStoreTests", timeOut = 30_000)
     public void succeedingStoreTests(SucceedingStoreTest storeTest) throws Exception {
         String storeNamePrefix = storeTest.getClass().getSimpleName() + "-";
 
@@ -86,7 +86,7 @@ public abstract class AbstractStoreTests {
         }
     }
 
-    @Test(dataProvider = "failingStoreTests")
+    @Test(dataProvider = "failingStoreTests", timeOut = 30_000)
     public void failingStoreTests(FailingStoreTest storeTest) throws Exception {
         String storeName = storeTest.getClass().getSimpleName();
 

--- a/iron-core/src/test/java/io/axway/iron/core/store/relation/RelationTests.java
+++ b/iron-core/src/test/java/io/axway/iron/core/store/relation/RelationTests.java
@@ -7,7 +7,8 @@ public class RelationTests extends AbstractStoreTests {
     public RelationTests() {
         super( //
                new ShouldDeleteRelationTailTest(), //
-               new ShouldUpdateSimpleRelationHeadTest() //
+               new ShouldUpdateSimpleRelationHeadTest(), //
+               new ShouldRollbackRelationTest() //
         );
     }
 }

--- a/iron-core/src/test/java/io/axway/iron/core/store/relation/ShouldRollbackRelationTest.java
+++ b/iron-core/src/test/java/io/axway/iron/core/store/relation/ShouldRollbackRelationTest.java
@@ -1,0 +1,69 @@
+package io.axway.iron.core.store.relation;
+
+import java.util.*;
+import javax.annotation.*;
+import com.google.common.collect.ImmutableList;
+import io.axway.iron.Command;
+import io.axway.iron.ReadWriteTransaction;
+import io.axway.iron.Store;
+import io.axway.iron.core.StoreManagerFactoryBuilder;
+import io.axway.iron.core.store.FailingStoreTest;
+import io.axway.iron.core.store.relation.command.CarChangeOwner;
+import io.axway.iron.core.store.relation.command.CarCreateCommand;
+import io.axway.iron.core.store.relation.command.CarSetAuthorizedDriversCommand;
+import io.axway.iron.core.store.relation.model.Car;
+import io.axway.iron.core.store.relation.model.Person;
+
+class ShouldRollbackRelationTest extends AbstractRelationTest implements FailingStoreTest {
+    @Override
+    public void configure(StoreManagerFactoryBuilder builder) throws Exception {
+        super.configure(builder);
+        builder.withCommandClass(CarFailingCommand.class);
+    }
+
+    public interface CarFailingCommand extends Command<Void> {
+        String plateNumber();
+
+        Collection<String> authorizedDrivers();
+
+        String previousOwner();
+
+        @Override
+        default Void execute(@Nonnull ReadWriteTransaction tx) {
+            Car car = tx.select(Car.class).where(Car::plateNumber).equalsTo(plateNumber());
+            Person previousOwner = tx.select(Person.class).where(Person::name).equalsTo(previousOwner());
+            Collection<Person> authorizedDrivers = tx.select(Person.class).where(Person::name).allContainedIn(authorizedDrivers());
+
+            tx.update(car) //
+                    .set(Car::authorizedDrivers).to(authorizedDrivers) //
+                    .set(Car::previousOwner).to(previousOwner) //
+                    .done();
+
+            throw new RuntimeException("Kaboom");
+        }
+    }
+
+    @Override
+    public void execute(Store store) throws Exception {
+        store.createCommand(CarCreateCommand.class) //
+                .set(CarCreateCommand::plateNumber).to("ZZZ") //
+                .set(CarCreateCommand::ownerName).to("john") //
+                .submit();
+
+        store.createCommand(CarSetAuthorizedDriversCommand.class) //
+                .set(CarSetAuthorizedDriversCommand::plateNumber).to("ZZZ") //
+                .set(CarSetAuthorizedDriversCommand::authorizedDrivers).to(ImmutableList.of("john")) //
+                .submit();
+
+        store.createCommand(CarChangeOwner.class) //
+                .set(CarChangeOwner::plateNumber).to("ZZZ") //
+                .set(CarChangeOwner::newOwnerName).to("marie") //
+                .submit();
+
+        store.createCommand(CarFailingCommand.class) //
+                .set(CarFailingCommand::plateNumber).to("ZZZ") //
+                .set(CarFailingCommand::authorizedDrivers).to(ImmutableList.of("marie")) //
+                .set(CarFailingCommand::previousOwner).to("anna") //
+                .submit().get();
+    }
+}


### PR DESCRIPTION
When a transaction is failing, relation rollback can produce a `java.lang.ClassCastException` and kill the `StoreManagerImpl` thread.

```
java.lang.ClassCastException: Cannot cast java.lang.Long to io.axway.iron.core.internal.entity.InstanceProxy
	at java.lang.Class.cast(Class.java:3369)
	at io.axway.iron.core.internal.entity.EntityStore.lambda$set$4(EntityStore.java:138)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.Iterator.forEachRemaining(Iterator.java:116)
	at java.util.Collections$UnmodifiableCollection$1.forEachRemaining(Collections.java:1049)
	at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
	at io.axway.iron.core.internal.entity.EntityStore.set(EntityStore.java:139)
	at io.axway.iron.core.internal.entity.EntityStore.update(EntityStore.java:212)
	at io.axway.iron.core.internal.transaction.ReadWriteTransactionImpl$UpdateObjectUpdater.lambda$null$0(ReadWriteTransactionImpl.java:118)
	at io.axway.iron.core.internal.transaction.ReadWriteTransactionImpl.rollback(ReadWriteTransactionImpl.java:29)
	at io.axway.iron.core.internal.StoreManagerImpl.consumerLoop(StoreManagerImpl.java:159)
	at java.lang.Thread.run(Thread.java:748)
```

This issue occurs because the stored operation for rollback is a `List` of `Long` (previous value of relation) and because the `EntityStore#set` method only expect a `List` of `InstanceProxy`.

My fix update the `EntityStore#set` method and accept a `List` of `Long` when updating a relation.

The API is unchanged and a user should not be able to update a relation using directly a `List<Long>`.