### PR TITLE
Fix incorrect osgi import for api bundle

### DIFF
--- a/iron-api/pom.xml
+++ b/iron-api/pom.xml
@@ -12,4 +12,7 @@
 
     <artifactId>iron-api</artifactId>
 
+    <properties>
+        <bnd.Import-Package>javax.annotation.*;version="0.0.0"</bnd.Import-Package>
+    </properties>
 </project>

--- a/iron-spi/pom.xml
+++ b/iron-spi/pom.xml
@@ -12,4 +12,7 @@
 
     <artifactId>iron-spi</artifactId>
 
+    <properties>
+        <bnd.Import-Package>javax.annotation.*;version="0.0.0"</bnd.Import-Package>
+    </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.encoding>${project.build.sourceEncoding}</maven.compiler.encoding>
+        <bnd.Import-Package>javax.annotation.*;version="0.0.0",com.google.common.*;version="15.0",*</bnd.Import-Package>
     </properties>
 
     <modules>
@@ -237,7 +238,7 @@
                         </goals>
                         <configuration>
                             <instructions>
-                                <Import-Package>javax.annotation.*;version="0.0.0",com.google.common.*;version="15.0",*</Import-Package>
+                                <Import-Package>${bnd.Import-Package}</Import-Package>
                             </instructions>
                         </configuration>
                     </execution>


### PR DESCRIPTION
For api bundles (`iron-api` & `iron-spi`), maven put the bundle package (bundle that starts by `io.axway.iron`) in the import instruction and prevent the bundle from being loaded by osgi.

This pull request add a parameter to not have the `Import-Package=*` for both `iron-api` & `iron-spi`